### PR TITLE
fix(*): Correct datasource environment variable typos

### DIFF
--- a/.local/.env.example
+++ b/.local/.env.example
@@ -4,8 +4,8 @@ export POSTGRES_PASSWORD=op://Development/local-postgres/password
 export POSTGRES_DB=golf
 
 export DATASOURCE_URL=jdbc:postgresql://localhost:9876/golf
-export DATASOURCE_USERNANME=op://Development/local-postgres/username
-export DATASOURCE_PASSOWRD=op://Development/local-postgres/password
+export DATASOURCE_USERNAME=op://Development/local-postgres/username
+export DATASOURCE_PASSWORD=op://Development/local-postgres/password
 
 export AUTH0_ISSUER_URL=op://Development/local-auth0/issuerUrl
 export AUTH0_AUDIENCE=op://Development/local-auth0/audience

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=golf
 
-spring.datasource.username=${DATASOURCE_USERNANME}
-spring.datasource.password=${DATASOURCE_PASSOWRD}
+spring.datasource.username=${DATASOURCE_USERNAME}
+spring.datasource.password=${DATASOURCE_PASSWORD}
 spring.datasource.url=${DATASOURCE_URL}
 
 okta.oauth2.issuer=${AUTH0_ISSUER_URL}


### PR DESCRIPTION
Fix typos in datasource configuration property names:
- DATASOURCE_USERNANME → DATASOURCE_USERNAME
- DATASOURCE_PASSOWRD → DATASOURCE_PASSWORD

Updated files:
- src/main/resources/application.properties: Fixed Spring property references
- .local/.env.example: Fixed environment variable export names

This ensures consistency with standard naming conventions and prevents confusion during environment setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)