### PR TITLE
Add 401 unauthenticated tests for all controllers

### DIFF
--- a/src/test/java/com/alimmit/golf/AbstractControllerMockMvc.java
+++ b/src/test/java/com/alimmit/golf/AbstractControllerMockMvc.java
@@ -21,4 +21,9 @@ public abstract class AbstractControllerMockMvc {
       throws Exception {
     return mockMvc.perform(builder.with(jwt().jwt(fn::apply))).andExpectAll(resultMatchers);
   }
+
+  protected ResultActions performWithoutAuth(
+      MockHttpServletRequestBuilder builder, ResultMatcher... resultMatchers) throws Exception {
+    return mockMvc.perform(builder).andExpectAll(resultMatchers);
+  }
 }

--- a/src/test/java/com/alimmit/golf/course/CourseControllerTest.java
+++ b/src/test/java/com/alimmit/golf/course/CourseControllerTest.java
@@ -4,6 +4,11 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.alimmit.golf.config.MethodSecurityConfiguration;
@@ -12,10 +17,13 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -171,6 +179,24 @@ class CourseControllerTest extends AbstractCourseControllerTest {
     UUID courseId = UUID.randomUUID();
     doNothing().when(courseService).delete(courseId);
     deleteCourse(courseId, JwtPersona.forAmyAdmin()).andExpect(status().isNoContent());
+  }
+
+  // --- Unauthenticated tests ---
+
+  @ParameterizedTest
+  @MethodSource
+  void unauthenticated_ExpectUnauthorized(MockHttpServletRequestBuilder request) throws Exception {
+    performWithoutAuth(request).andExpect(status().isUnauthorized());
+  }
+
+  static Stream<MockHttpServletRequestBuilder> unauthenticated_ExpectUnauthorized() {
+    UUID id = UUID.randomUUID();
+    return Stream.of(
+        get(CourseConstants.COURSE_ENDPOINT),
+        get(CourseConstants.COURSE_ENDPOINT + "/{id}", id),
+        post(CourseConstants.COURSE_ENDPOINT).with(csrf()),
+        patch(CourseConstants.COURSE_ENDPOINT + "/{id}", id).with(csrf()),
+        delete(CourseConstants.COURSE_ENDPOINT + "/{id}", id).with(csrf()));
   }
 
   @ParameterizedTest

--- a/src/test/java/com/alimmit/golf/course/TeeControllerTest.java
+++ b/src/test/java/com/alimmit/golf/course/TeeControllerTest.java
@@ -4,6 +4,11 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import com.alimmit.golf.config.MethodSecurityConfiguration;
@@ -13,9 +18,12 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -177,6 +185,25 @@ class TeeControllerTest extends AbstractTeeControllerTest {
         """;
 
     createTee(courseId, requestBody, JwtPersona.forAmyAdmin()).andExpect(status().isNotFound());
+  }
+
+  // --- Unauthenticated tests ---
+
+  @ParameterizedTest
+  @MethodSource
+  void unauthenticated_ExpectUnauthorized(MockHttpServletRequestBuilder request) throws Exception {
+    performWithoutAuth(request).andExpect(status().isUnauthorized());
+  }
+
+  static Stream<MockHttpServletRequestBuilder> unauthenticated_ExpectUnauthorized() {
+    UUID courseId = UUID.randomUUID();
+    UUID teeId = UUID.randomUUID();
+    return Stream.of(
+        get(TeeConstants.TEE_ENDPOINT, courseId),
+        get(TeeConstants.TEE_BY_ID_ENDPOINT, teeId),
+        post(TeeConstants.TEE_ENDPOINT, courseId).with(csrf()),
+        patch(TeeConstants.TEE_BY_ID_ENDPOINT, teeId).with(csrf()),
+        delete(TeeConstants.TEE_BY_ID_ENDPOINT, teeId).with(csrf()));
   }
 
   @ParameterizedTest

--- a/src/test/java/com/alimmit/golf/handicap/HandicapControllerTest.java
+++ b/src/test/java/com/alimmit/golf/handicap/HandicapControllerTest.java
@@ -1,9 +1,11 @@
 package com.alimmit.golf.handicap;
 
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.alimmit.golf.GlobalConstants;
 import com.alimmit.golf.config.MethodSecurityConfiguration;
 import com.alimmit.golf.courses.client.GolfCourseApiClient;
 import com.alimmit.golf.scorecard.ScorecardService;
@@ -12,9 +14,12 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -88,6 +93,20 @@ class HandicapControllerTest extends AbstractHandicapControllerMockMvc {
                     Instant.now())));
 
     super.getMyHandicapHistory(JwtPersona.forGaryGolfer()).andExpect(status().isOk());
+  }
+
+  // --- Unauthenticated tests ---
+
+  @ParameterizedTest
+  @MethodSource
+  void unauthenticated_ExpectUnauthorized(MockHttpServletRequestBuilder request) throws Exception {
+    performWithoutAuth(request).andExpect(status().isUnauthorized());
+  }
+
+  static Stream<MockHttpServletRequestBuilder> unauthenticated_ExpectUnauthorized() {
+    return Stream.of(
+        get(HandicapConstants.HANDICAP_ENDPOINT),
+        get(HandicapConstants.HANDICAP_ENDPOINT + GlobalConstants.API_HISTORY_SUFFIX));
   }
 
   // --- Authorization tests ---

--- a/src/test/java/com/alimmit/golf/scorecard/ScorecardControllerTest.java
+++ b/src/test/java/com/alimmit/golf/scorecard/ScorecardControllerTest.java
@@ -2,6 +2,10 @@ package com.alimmit.golf.scorecard;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -14,9 +18,12 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -221,6 +228,25 @@ class ScorecardControllerTest extends AbstractScorecardControllerMockMvc {
     when(scorecardService.deleteById(scorecardId)).thenReturn(1);
     deleteScorecard(JwtPersona.forGaryGolfer(JwtPersona.SCOPE_WRITE_SCORECARD), scorecardId)
         .andExpect(status().isNoContent());
+  }
+
+  // --- Validation tests ---
+
+  // --- Unauthenticated tests ---
+
+  @ParameterizedTest
+  @MethodSource
+  void unauthenticated_ExpectUnauthorized(MockHttpServletRequestBuilder request) throws Exception {
+    performWithoutAuth(request).andExpect(status().isUnauthorized());
+  }
+
+  static Stream<MockHttpServletRequestBuilder> unauthenticated_ExpectUnauthorized() {
+    UUID id = UUID.randomUUID();
+    return Stream.of(
+        post(ScorecardConstants.SCORECARD_ENDPOINT).with(csrf()),
+        get(ScorecardConstants.SCORECARD_ENDPOINT),
+        get(ScorecardConstants.SCORECARD_ENDPOINT + "/{id}", id),
+        delete(ScorecardConstants.SCORECARD_ENDPOINT + "/{id}", id).with(csrf()));
   }
 
   // --- Validation tests ---


### PR DESCRIPTION
## Summary

- Adds `performWithoutAuth` helper to `AbstractControllerMockMvc` for making requests without a JWT
- Adds parameterized `unauthenticated_ExpectUnauthorized` tests to `ScorecardController`, `CourseController`, `TeeController`, and `HandicapController`, covering every endpoint
- Uses `.with(csrf())` on POST/PATCH/DELETE requests so the authentication layer rejects them (401), not the CSRF filter (403)

## Test plan

- [ ] All 159 tests pass, 1 skipped (`CourseRepositoryTest` is `@Disabled`)
- [ ] Each controller test now includes a parameterized case asserting every endpoint returns 401 when called without a JWT

🤖 Generated with [Claude Code](https://claude.com/claude-code)