### PR TITLE
Rename entity primary key fields to 'id'

### DIFF
--- a/src/main/java/com/alimmit/golf/course/CourseEntity.java
+++ b/src/main/java/com/alimmit/golf/course/CourseEntity.java
@@ -22,11 +22,12 @@ class CourseEntity {
   @Id
   @Generated(sql = "uuidv7()", writable = true)
   @Column(
+      name = "course_id",
       unique = true,
       updatable = false,
       nullable = false,
       columnDefinition = "UUID DEFAULT uuidv7()")
-  private UUID courseId;
+  private UUID id;
 
   @CreatedDate
   @NotAudited
@@ -68,8 +69,8 @@ class CourseEntity {
     this.state = state;
   }
 
-  public UUID getCourseId() {
-    return courseId;
+  public UUID getId() {
+    return id;
   }
 
   public Instant getCreatedAt() {
@@ -112,8 +113,8 @@ class CourseEntity {
     this.state = state;
   }
 
-  public void setCourseId(UUID courseId) {
-    this.courseId = courseId;
+  public void setId(UUID id) {
+    this.id = id;
   }
 
   public void setCreatedAt(Instant createdAt) {
@@ -124,7 +125,7 @@ class CourseEntity {
   public boolean equals(Object o) {
     if (o == null || getClass() != o.getClass()) return false;
     CourseEntity that = (CourseEntity) o;
-    return Objects.equals(courseId, that.courseId)
+    return Objects.equals(id, that.id)
         && Objects.equals(club, that.club)
         && Objects.equals(course, that.course)
         && Objects.equals(city, that.city)
@@ -133,7 +134,7 @@ class CourseEntity {
 
   @Override
   public int hashCode() {
-    return Objects.hash(courseId, club, course, city, state);
+    return Objects.hash(id, club, course, city, state);
   }
 
   @Override

--- a/src/main/java/com/alimmit/golf/course/CourseMapper.java
+++ b/src/main/java/com/alimmit/golf/course/CourseMapper.java
@@ -16,7 +16,7 @@ class CourseMapper {
 
   CourseDto map(CourseEntity entity) {
     return new CourseDto(
-        entity.getCourseId(),
+        entity.getId(),
         entity.getCreatedAt(),
         entity.getLastModifiedAt(),
         entity.getClub(),

--- a/src/main/java/com/alimmit/golf/course/JpaCourseServiceImpl.java
+++ b/src/main/java/com/alimmit/golf/course/JpaCourseServiceImpl.java
@@ -59,7 +59,7 @@ class JpaCourseServiceImpl implements CourseService {
   @Override
   @Transactional
   public void delete(UUID courseId) {
-    teeRepository.deleteByCourse_CourseId(courseId);
+    teeRepository.deleteByCourse_Id(courseId);
     courseRepository.deleteById(courseId);
   }
 }

--- a/src/main/java/com/alimmit/golf/course/JpaTeeServiceImpl.java
+++ b/src/main/java/com/alimmit/golf/course/JpaTeeServiceImpl.java
@@ -23,7 +23,7 @@ class JpaTeeServiceImpl implements TeeService {
   @Override
   @Transactional(readOnly = true)
   public List<TeeDto> listByCourse(UUID courseId) {
-    return teeRepository.findByCourse_CourseId(courseId).stream().map(teeMapper::map).toList();
+    return teeRepository.findByCourse_Id(courseId).stream().map(teeMapper::map).toList();
   }
 
   @Override

--- a/src/main/java/com/alimmit/golf/course/TeeEntity.java
+++ b/src/main/java/com/alimmit/golf/course/TeeEntity.java
@@ -23,11 +23,12 @@ class TeeEntity {
   @Id
   @Generated(sql = "uuidv7()", writable = true)
   @Column(
+      name = "tee_id",
       unique = true,
       updatable = false,
       nullable = false,
       columnDefinition = "UUID DEFAULT uuidv7()")
-  private UUID teeId;
+  private UUID id;
 
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "course_id", nullable = false, updatable = false)
@@ -83,8 +84,8 @@ class TeeEntity {
     this.rating = rating;
   }
 
-  public UUID getTeeId() {
-    return teeId;
+  public UUID getId() {
+    return id;
   }
 
   public CourseEntity getCourse() {
@@ -119,8 +120,8 @@ class TeeEntity {
     return rating;
   }
 
-  public void setTeeId(UUID teeId) {
-    this.teeId = teeId;
+  public void setId(UUID id) {
+    this.id = id;
   }
 
   public void setCreatedAt(Instant createdAt) {
@@ -151,7 +152,7 @@ class TeeEntity {
   public boolean equals(Object o) {
     if (o == null || getClass() != o.getClass()) return false;
     TeeEntity that = (TeeEntity) o;
-    return Objects.equals(teeId, that.teeId)
+    return Objects.equals(id, that.id)
         && Objects.equals(name, that.name)
         && Objects.equals(par, that.par)
         && Objects.equals(yardage, that.yardage)
@@ -161,7 +162,7 @@ class TeeEntity {
 
   @Override
   public int hashCode() {
-    return Objects.hash(teeId, name, par, yardage, slope, rating);
+    return Objects.hash(id, name, par, yardage, slope, rating);
   }
 
   @Override

--- a/src/main/java/com/alimmit/golf/course/TeeMapper.java
+++ b/src/main/java/com/alimmit/golf/course/TeeMapper.java
@@ -22,8 +22,8 @@ class TeeMapper {
 
   TeeDto map(TeeEntity entity) {
     return new TeeDto(
-        entity.getTeeId(),
-        entity.getCourse().getCourseId(),
+        entity.getId(),
+        entity.getCourse().getId(),
         entity.getCreatedAt(),
         entity.getLastModifiedAt(),
         entity.getName(),

--- a/src/main/java/com/alimmit/golf/course/TeeRepository.java
+++ b/src/main/java/com/alimmit/golf/course/TeeRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 interface TeeRepository extends JpaRepository<TeeEntity, UUID> {
 
-  List<TeeEntity> findByCourse_CourseId(UUID courseId);
+  List<TeeEntity> findByCourse_Id(UUID courseId);
 
-  void deleteByCourse_CourseId(UUID courseId);
+  void deleteByCourse_Id(UUID courseId);
 }

--- a/src/main/java/com/alimmit/golf/handicap/HandicapEntity.java
+++ b/src/main/java/com/alimmit/golf/handicap/HandicapEntity.java
@@ -24,7 +24,7 @@ class HandicapEntity {
       nullable = false,
       updatable = false,
       columnDefinition = "UUID DEFAULT uuidv7()")
-  private UUID handicapId;
+  private UUID id;
 
   @CreatedDate
   @NotAudited
@@ -77,8 +77,8 @@ class HandicapEntity {
     this.totalRounds = totalRounds;
   }
 
-  public UUID getHandicapId() {
-    return handicapId;
+  public UUID getId() {
+    return id;
   }
 
   public Instant getCreatedAt() {
@@ -109,7 +109,7 @@ class HandicapEntity {
   public boolean equals(Object o) {
     if (o == null || getClass() != o.getClass()) return false;
     HandicapEntity entity = (HandicapEntity) o;
-    return Objects.equals(handicapId, entity.handicapId)
+    return Objects.equals(id, entity.id)
         && Objects.equals(createdAt, entity.createdAt)
         && Objects.equals(lastModifiedAt, entity.lastModifiedAt)
         && Objects.equals(golferId, entity.golferId)
@@ -121,14 +121,14 @@ class HandicapEntity {
   @Override
   public int hashCode() {
     return Objects.hash(
-        handicapId, createdAt, lastModifiedAt, golferId, handicapIndex, roundsUsed, totalRounds);
+        id, createdAt, lastModifiedAt, golferId, handicapIndex, roundsUsed, totalRounds);
   }
 
   @Override
   public String toString() {
     return "HandicapEntity{"
-        + "handicapId='"
-        + handicapId
+        + "id='"
+        + id
         + '\''
         + ", golferId='"
         + golferId

--- a/src/main/java/com/alimmit/golf/handicap/HandicapMapper.java
+++ b/src/main/java/com/alimmit/golf/handicap/HandicapMapper.java
@@ -24,7 +24,7 @@ class HandicapMapper {
 
   HandicapDto toDto(HandicapEntity entity) {
     return new HandicapDto(
-        entity.getHandicapId(),
+        entity.getId(),
         entity.getGolferId(),
         entity.getCreatedAt(),
         entity.getLastModifiedAt(),
@@ -36,7 +36,7 @@ class HandicapMapper {
   HandicapRevisionDto toRevision(Revision<Integer, HandicapEntity> revision) {
     HandicapEntity entity = revision.getEntity();
     return new HandicapRevisionDto(
-        entity.getHandicapId(),
+        entity.getId(),
         entity.getGolferId(),
         entity.getCreatedAt(),
         entity.getLastModifiedAt(),

--- a/src/main/java/com/alimmit/golf/handicap/JpaHandicapServiceImpl.java
+++ b/src/main/java/com/alimmit/golf/handicap/JpaHandicapServiceImpl.java
@@ -54,7 +54,7 @@ class JpaHandicapServiceImpl implements HandicapService {
     HandicapEntity handicap =
         handicapRepository.findHandicapForCurrentUser().orElseThrow(NotFoundException::new);
     Revisions<Integer, HandicapEntity> revisions =
-        handicapRepository.findRevisions(handicap.getHandicapId());
+        handicapRepository.findRevisions(handicap.getId());
     return revisions.stream().map(handicapMapper::toRevision).toList();
   }
 }

--- a/src/main/java/com/alimmit/golf/scorecard/ScorecardEntity.java
+++ b/src/main/java/com/alimmit/golf/scorecard/ScorecardEntity.java
@@ -17,8 +17,12 @@ class ScorecardEntity {
 
   @Id
   @Generated(sql = "uuidv7()", writable = true)
-  @Column(updatable = false, nullable = false, columnDefinition = "UUID DEFAULT uuidv7()")
-  private UUID scorecardId;
+  @Column(
+      name = "scorecard_id",
+      updatable = false,
+      nullable = false,
+      columnDefinition = "UUID DEFAULT uuidv7()")
+  private UUID id;
 
   @CreatedDate
   @Column(nullable = false, updatable = false)
@@ -84,12 +88,12 @@ class ScorecardEntity {
     this.indexEstablished = indexEstablished;
   }
 
-  public UUID getScorecardId() {
-    return scorecardId;
+  public UUID getId() {
+    return id;
   }
 
-  public void setScorecardId(UUID scorecardId) {
-    this.scorecardId = scorecardId;
+  public void setId(UUID id) {
+    this.id = id;
   }
 
   public Instant getCreatedAt() {
@@ -145,21 +149,12 @@ class ScorecardEntity {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     ScorecardEntity that = (ScorecardEntity) o;
-    return Objects.equals(scorecardId, that.scorecardId);
+    return Objects.equals(id, that.id);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        scorecardId,
-        createdAt,
-        createdBy,
-        scoreDate,
-        courseName,
-        score,
-        par,
-        rating,
-        slope,
-        scorecardType);
+        id, createdAt, createdBy, scoreDate, courseName, score, par, rating, slope, scorecardType);
   }
 }

--- a/src/main/java/com/alimmit/golf/scorecard/ScorecardMapper.java
+++ b/src/main/java/com/alimmit/golf/scorecard/ScorecardMapper.java
@@ -10,7 +10,7 @@ class ScorecardMapper {
   /** Convert entity to DTO for API responses. */
   ScorecardDto toDto(ScorecardEntity entity) {
     return new ScorecardDto(
-        entity.getScorecardId(),
+        entity.getId(),
         entity.getCreatedAt(),
         entity.getCreatedBy(),
         entity.getScoreDate(),

--- a/src/main/java/com/alimmit/golf/scorecard/ScorecardRepository.java
+++ b/src/main/java/com/alimmit/golf/scorecard/ScorecardRepository.java
@@ -42,7 +42,7 @@ interface ScorecardRepository extends JpaRepository<ScorecardEntity, String> {
    * @return the scorecard if found and belongs to current user
    */
   @Query(
-      "SELECT s FROM ScorecardEntity s WHERE s.scorecardId = :scorecardId AND s.createdBy = ?#{authentication.name}")
+      "SELECT s FROM ScorecardEntity s WHERE s.id = :scorecardId AND s.createdBy = ?#{authentication.name}")
   Optional<ScorecardEntity> findByIdForCurrentUser(@Param("scorecardId") UUID scorecardId);
 
   /**
@@ -55,6 +55,6 @@ interface ScorecardRepository extends JpaRepository<ScorecardEntity, String> {
    */
   @Modifying
   @Query(
-      "DELETE FROM ScorecardEntity s WHERE s.scorecardId = :scorecardId AND s.createdBy = ?#{authentication.name}")
+      "DELETE FROM ScorecardEntity s WHERE s.id = :scorecardId AND s.createdBy = ?#{authentication.name}")
   int deleteByIdForCurrentUser(@Param("scorecardId") UUID scorecardId);
 }

--- a/src/test/java/com/alimmit/golf/course/CourseMapperTest.java
+++ b/src/test/java/com/alimmit/golf/course/CourseMapperTest.java
@@ -28,7 +28,7 @@ class CourseMapperTest {
     Instant createdAt = Instant.parse("2026-01-01T00:00:00Z");
 
     CourseEntity entity = new CourseEntity("Test Club", "Test Course", "Test City", USState.OHIO);
-    entity.setCourseId(courseId);
+    entity.setId(courseId);
     entity.setCreatedAt(createdAt);
 
     CourseDto result = courseMapper.map(entity);
@@ -46,7 +46,7 @@ class CourseMapperTest {
 
     CourseEntity entity =
         new CourseEntity("Test Club", "Test Course", "Test City", USState.WISCONSIN);
-    entity.setCourseId(courseId);
+    entity.setId(courseId);
     entity.setCreatedAt(createdAt);
 
     Optional<CourseDto> result = courseMapper.map(Optional.of(entity));

--- a/src/test/java/com/alimmit/golf/course/CourseRepositoryTest.java
+++ b/src/test/java/com/alimmit/golf/course/CourseRepositoryTest.java
@@ -79,11 +79,11 @@ class CourseRepositoryTest {
         .hasFieldOrPropertyWithValue("city", "Somewhere")
         .hasFieldOrPropertyWithValue("state", USState.WISCONSIN);
 
-    Optional<CourseEntity> read = courseRepository.findById(saved.getCourseId());
+    Optional<CourseEntity> read = courseRepository.findById(saved.getId());
     assertThat(read)
         .isPresent()
         .get()
-        .hasFieldOrPropertyWithValue("courseId", saved.getCourseId())
+        .hasFieldOrPropertyWithValue("id", saved.getId())
         .hasFieldOrProperty("createdAt")
         .hasFieldOrPropertyWithValue("createdBy", "123")
         .hasFieldOrProperty("lastModifiedAt")
@@ -101,7 +101,7 @@ class CourseRepositoryTest {
 
     CourseEntity updated = courseRepository.save(toUpdate);
     assertThat(updated)
-        .hasFieldOrPropertyWithValue("courseId", saved.getCourseId())
+        .hasFieldOrPropertyWithValue("id", saved.getId())
         .hasFieldOrProperty("createdAt")
         .hasFieldOrPropertyWithValue("createdBy", "123")
         .hasFieldOrProperty("lastModifiedAt")
@@ -115,6 +115,6 @@ class CourseRepositoryTest {
 
     courseRepository.delete(updated);
 
-    assertThat(courseRepository.findById(saved.getCourseId())).isEmpty();
+    assertThat(courseRepository.findById(saved.getId())).isEmpty();
   }
 }

--- a/src/test/java/com/alimmit/golf/course/JpaCourseServiceImplTest.java
+++ b/src/test/java/com/alimmit/golf/course/JpaCourseServiceImplTest.java
@@ -130,20 +130,20 @@ class JpaCourseServiceImplTest {
 
     courseService.delete(courseId);
 
-    verify(teeRepository).deleteByCourse_CourseId(courseId);
+    verify(teeRepository).deleteByCourse_Id(courseId);
     verify(courseRepository).deleteById(courseId);
   }
 
   private CourseEntity createEntity(UUID courseId, String club, String course) {
     CourseEntity entity = new CourseEntity(club, course, "Test City", USState.WISCONSIN);
-    entity.setCourseId(courseId);
+    entity.setId(courseId);
     entity.setCreatedAt(Instant.now());
     return entity;
   }
 
   private CourseDto createDto(CourseEntity entity) {
     return new CourseDto(
-        entity.getCourseId(),
+        entity.getId(),
         entity.getCreatedAt(),
         Instant.now(),
         entity.getClub(),

--- a/src/test/java/com/alimmit/golf/course/JpaTeeServiceImplTest.java
+++ b/src/test/java/com/alimmit/golf/course/JpaTeeServiceImplTest.java
@@ -37,7 +37,7 @@ class JpaTeeServiceImplTest {
     TeeDto dto1 = createDto(entity1);
     TeeDto dto2 = createDto(entity2);
 
-    when(teeRepository.findByCourse_CourseId(courseId)).thenReturn(List.of(entity1, entity2));
+    when(teeRepository.findByCourse_Id(courseId)).thenReturn(List.of(entity1, entity2));
     when(teeMapper.map(entity1)).thenReturn(dto1);
     when(teeMapper.map(entity2)).thenReturn(dto2);
 
@@ -78,7 +78,7 @@ class JpaTeeServiceImplTest {
   void create() {
     UUID courseId = UUID.randomUUID();
     CourseEntity course = new CourseEntity("Test Club", "Test Course", "Test City", USState.OHIO);
-    course.setCourseId(courseId);
+    course.setId(courseId);
 
     CreateTeeRequest request =
         new CreateTeeRequest("Blue", 72, 6500, new BigDecimal("131.0"), new BigDecimal("71.2"));
@@ -163,19 +163,19 @@ class JpaTeeServiceImplTest {
 
   private TeeEntity createEntity(UUID teeId, String name) {
     CourseEntity course = new CourseEntity("Test Club", "Test Course", "Test City", USState.OHIO);
-    course.setCourseId(UUID.randomUUID());
+    course.setId(UUID.randomUUID());
 
     TeeEntity entity =
         new TeeEntity(course, name, 72, 6500, new BigDecimal("131.0"), new BigDecimal("71.2"));
-    entity.setTeeId(teeId);
+    entity.setId(teeId);
     entity.setCreatedAt(Instant.now());
     return entity;
   }
 
   private TeeDto createDto(TeeEntity entity) {
     return new TeeDto(
-        entity.getTeeId(),
-        entity.getCourse().getCourseId(),
+        entity.getId(),
+        entity.getCourse().getId(),
         entity.getCreatedAt(),
         Instant.now(),
         entity.getName(),

--- a/src/test/java/com/alimmit/golf/course/TeeMapperTest.java
+++ b/src/test/java/com/alimmit/golf/course/TeeMapperTest.java
@@ -33,11 +33,11 @@ class TeeMapperTest {
     Instant createdAt = Instant.parse("2026-01-01T00:00:00Z");
 
     CourseEntity course = new CourseEntity("Test Club", "Test Course", "Test City", USState.OHIO);
-    course.setCourseId(courseId);
+    course.setId(courseId);
 
     TeeEntity entity =
         new TeeEntity(course, "White", 72, 6100, new BigDecimal("125.0"), new BigDecimal("69.5"));
-    entity.setTeeId(teeId);
+    entity.setId(teeId);
     entity.setCreatedAt(createdAt);
 
     TeeDto result = teeMapper.map(entity);
@@ -63,11 +63,11 @@ class TeeMapperTest {
     Instant createdAt = Instant.parse("2026-01-01T00:00:00Z");
 
     CourseEntity course = new CourseEntity("Test Club", "Test Course", "Test City", USState.OHIO);
-    course.setCourseId(courseId);
+    course.setId(courseId);
 
     TeeEntity entity =
         new TeeEntity(course, "Blue", 72, 6500, new BigDecimal("131.0"), new BigDecimal("71.2"));
-    entity.setTeeId(teeId);
+    entity.setId(teeId);
     entity.setCreatedAt(createdAt);
 
     Optional<TeeDto> result = teeMapper.map(Optional.of(entity));

--- a/src/test/java/com/alimmit/golf/course/TeeRepositoryTest.java
+++ b/src/test/java/com/alimmit/golf/course/TeeRepositoryTest.java
@@ -76,7 +76,7 @@ class TeeRepositoryTest {
                 course, "Blue", 72, 6500, new BigDecimal("131.0"), new BigDecimal("71.2")));
 
     assertThat(saved)
-        .hasFieldOrProperty("teeId")
+        .hasFieldOrProperty("id")
         .hasFieldOrProperty("createdAt")
         .hasFieldOrPropertyWithValue("createdBy", "123")
         .hasFieldOrProperty("lastModifiedAt")
@@ -87,11 +87,11 @@ class TeeRepositoryTest {
         .hasFieldOrPropertyWithValue("slope", new BigDecimal("131.0"))
         .hasFieldOrPropertyWithValue("rating", new BigDecimal("71.2"));
 
-    Optional<TeeEntity> read = teeRepository.findById(saved.getTeeId());
+    Optional<TeeEntity> read = teeRepository.findById(saved.getId());
     assertThat(read)
         .isPresent()
         .get()
-        .hasFieldOrPropertyWithValue("teeId", saved.getTeeId())
+        .hasFieldOrPropertyWithValue("id", saved.getId())
         .hasFieldOrPropertyWithValue("name", "Blue")
         .hasFieldOrPropertyWithValue("yardage", 6500);
 
@@ -103,7 +103,7 @@ class TeeRepositoryTest {
 
     TeeEntity updated = teeRepository.save(toUpdate);
     assertThat(updated)
-        .hasFieldOrPropertyWithValue("teeId", saved.getTeeId())
+        .hasFieldOrPropertyWithValue("id", saved.getId())
         .hasFieldOrPropertyWithValue("name", "White")
         .hasFieldOrPropertyWithValue("yardage", 6100)
         .hasFieldOrPropertyWithValue("slope", new BigDecimal("125.0"))
@@ -113,7 +113,7 @@ class TeeRepositoryTest {
 
     teeRepository.delete(updated);
 
-    assertThat(teeRepository.findById(saved.getTeeId())).isEmpty();
+    assertThat(teeRepository.findById(saved.getId())).isEmpty();
   }
 
   @Test
@@ -136,14 +136,14 @@ class TeeRepositoryTest {
     teeRepository.save(
         new TeeEntity(course2, "Red", 72, 5200, new BigDecimal("118.0"), new BigDecimal("66.0")));
 
-    List<TeeEntity> course1Tees = teeRepository.findByCourse_CourseId(course1.getCourseId());
+    List<TeeEntity> course1Tees = teeRepository.findByCourse_Id(course1.getId());
 
     assertThat(course1Tees)
         .hasSize(2)
         .extracting(TeeEntity::getName)
         .containsExactlyInAnyOrder("Blue", "White");
 
-    List<TeeEntity> course2Tees = teeRepository.findByCourse_CourseId(course2.getCourseId());
+    List<TeeEntity> course2Tees = teeRepository.findByCourse_Id(course2.getId());
 
     assertThat(course2Tees).hasSize(1).extracting(TeeEntity::getName).containsExactly("Red");
   }
@@ -152,7 +152,7 @@ class TeeRepositoryTest {
   @WithMockUser("123")
   @Transactional(propagation = Propagation.NEVER)
   void findByCourseIdEmpty() {
-    List<TeeEntity> result = teeRepository.findByCourse_CourseId(java.util.UUID.randomUUID());
+    List<TeeEntity> result = teeRepository.findByCourse_Id(java.util.UUID.randomUUID());
 
     assertThat(result).isEmpty();
   }

--- a/src/test/java/com/alimmit/golf/handicap/HandicapRepositoryTest.java
+++ b/src/test/java/com/alimmit/golf/handicap/HandicapRepositoryTest.java
@@ -80,7 +80,7 @@ class HandicapRepositoryTest {
 
     // Then: Audit fields should be populated automatically
     assertThat(saved)
-        .hasFieldOrProperty("handicapId")
+        .hasFieldOrProperty("id")
         .hasFieldOrPropertyWithValue("golferId", JwtPersona.GARY_GOLFER.sub())
         .hasFieldOrProperty("createdAt")
         .hasFieldOrProperty("lastModifiedAt")
@@ -136,7 +136,7 @@ class HandicapRepositoryTest {
     // WHEN: fetching handicap revision history
     setSecurityContext(JwtPersona.GARY_GOLFER.sub());
     Revisions<Integer, HandicapEntity> revisions =
-        handicapRepository.findRevisions(handicap.getHandicapId());
+        handicapRepository.findRevisions(handicap.getId());
 
     // THEN: the history contains three handicaps
     assertThat(revisions).hasSize(3);

--- a/src/test/java/com/alimmit/golf/scorecard/ScorecardRepositoryTest.java
+++ b/src/test/java/com/alimmit/golf/scorecard/ScorecardRepositoryTest.java
@@ -85,7 +85,7 @@ class ScorecardRepositoryTest {
 
     // Then: Audit fields should be populated automatically
     Assertions.assertThat(saved)
-        .hasFieldOrProperty("scorecardId")
+        .hasFieldOrProperty("id")
         .hasFieldOrPropertyWithValue("createdBy", JwtPersona.GARY_GOLFER.sub())
         .hasFieldOrProperty("createdAt")
         .hasFieldOrPropertyWithValue("courseName", "Test Course")
@@ -134,16 +134,15 @@ class ScorecardRepositoryTest {
 
     // When: Gary looks up his own scorecard
     Optional<ScorecardEntity> garyResult =
-        scorecardRepository.findByIdForCurrentUser(saved.getScorecardId());
+        scorecardRepository.findByIdForCurrentUser(saved.getId());
 
     // Then: Scorecard should be found
     assertThat(garyResult).isPresent();
-    assertThat(garyResult.get().getScorecardId()).isEqualTo(saved.getScorecardId());
+    assertThat(garyResult.get().getId()).isEqualTo(saved.getId());
 
     // When: Pat tries to access Gary's scorecard
     setSecurityContext(JwtPersona.PAT_PUTTER.sub());
-    Optional<ScorecardEntity> patResult =
-        scorecardRepository.findByIdForCurrentUser(saved.getScorecardId());
+    Optional<ScorecardEntity> patResult = scorecardRepository.findByIdForCurrentUser(saved.getId());
 
     // Then: Scorecard should not be found (authorization check)
     assertThat(patResult).isEmpty();
@@ -157,21 +156,21 @@ class ScorecardRepositoryTest {
 
     // When: Pat tries to delete Gary's scorecard
     setSecurityContext(JwtPersona.PAT_PUTTER.sub());
-    int patDeleteCount = scorecardRepository.deleteByIdForCurrentUser(saved.getScorecardId());
+    int patDeleteCount = scorecardRepository.deleteByIdForCurrentUser(saved.getId());
 
     // Then: Nothing should be deleted (authorization check)
     assertThat(patDeleteCount).isZero();
 
     // Verify scorecard still exists
     setSecurityContext(JwtPersona.GARY_GOLFER.sub());
-    assertThat(scorecardRepository.findByIdForCurrentUser(saved.getScorecardId())).isPresent();
+    assertThat(scorecardRepository.findByIdForCurrentUser(saved.getId())).isPresent();
 
     // When: Gary deletes his own scorecard
-    int garyDeleteCount = scorecardRepository.deleteByIdForCurrentUser(saved.getScorecardId());
+    int garyDeleteCount = scorecardRepository.deleteByIdForCurrentUser(saved.getId());
 
     // Then: Scorecard should be deleted
     assertThat(garyDeleteCount).isEqualTo(1);
-    assertThat(scorecardRepository.findByIdForCurrentUser(saved.getScorecardId())).isEmpty();
+    assertThat(scorecardRepository.findByIdForCurrentUser(saved.getId())).isEmpty();
   }
 
   private ScorecardEntity createScorecard(Integer score) {


### PR DESCRIPTION
## Summary

- Renames `scorecardId`, `handicapId`, `courseId`, and `teeId` fields to `id` on `ScorecardEntity`, `HandicapEntity`, `CourseEntity`, and `TeeEntity`
- Preserves existing DB column names via explicit `@Column(name = "...")` mappings — no schema changes required
- Updates all getters/setters, equals/hashCode, JPQL queries, Spring Data derived query method names, mappers, services, and tests accordingly

## Test plan

- [x] All 159 tests pass (`./mvnw test`)
- [x] Spotless formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)