### PR TITLE
Add full-text search endpoint for golf courses

### DIFF
--- a/src/main/java/com/alimmit/golf/course/CourseConstants.java
+++ b/src/main/java/com/alimmit/golf/course/CourseConstants.java
@@ -7,4 +7,6 @@ final class CourseConstants {
   private CourseConstants() {}
 
   static final String COURSE_ENDPOINT = GlobalConstants.API_V1_PREFIX + "/course";
+
+  static final String COURSE_SEARCH_SUFFIX = "/search";
 }

--- a/src/main/java/com/alimmit/golf/course/CourseController.java
+++ b/src/main/java/com/alimmit/golf/course/CourseController.java
@@ -13,14 +13,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+@Validated
 @RestController
 @RequestMapping(path = CourseConstants.COURSE_ENDPOINT)
 @Tag(name = "Courses")
@@ -142,5 +145,25 @@ class CourseController {
   void delete(@PathVariable("id") UUID courseId) {
     logger.debug("delete course | id={}", courseId);
     courseService.delete(courseId);
+  }
+
+  @Operation(
+      method = "GET",
+      operationId = "course.search",
+      summary = "Search golf courses",
+      description = "Full-text search across club, course, city, and state fields",
+      parameters = {@Parameter(name = "q", description = "Search query", in = ParameterIn.QUERY)},
+      responses =
+          @ApiResponse(
+              responseCode = "200",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON_VALUE,
+                      array = @ArraySchema(schema = @Schema(implementation = CourseDto.class)))))
+  @CanRead(GlobalConstants.SCOPE_COURSE)
+  @GetMapping(path = CourseConstants.COURSE_SEARCH_SUFFIX)
+  List<CourseDto> search(@RequestParam @NotBlank String q) {
+    logger.debug("search courses | q={}", q);
+    return courseService.search(q);
   }
 }

--- a/src/main/java/com/alimmit/golf/course/CourseRepository.java
+++ b/src/main/java/com/alimmit/golf/course/CourseRepository.java
@@ -15,4 +15,17 @@ interface CourseRepository extends JpaRepository<CourseEntity, UUID> {
   @Query(
       "SELECT c FROM CourseEntity c WHERE c.id = :courseId AND c.createdBy = ?#{authentication.name}")
   Optional<CourseEntity> findByIdForCurrentUser(@Param("courseId") UUID courseId);
+
+  @Query(
+      value =
+          """
+          SELECT course_id, created_at, created_by, last_modified_at, last_modified_by,
+                 club, course, city, state
+          FROM course
+          WHERE created_by = ?#{authentication.name}
+          AND search_vector @@ to_tsquery('english', :query)
+          ORDER BY ts_rank(search_vector, to_tsquery('english', :query)) DESC
+          """,
+      nativeQuery = true)
+  List<CourseEntity> search(@Param("query") String query);
 }

--- a/src/main/java/com/alimmit/golf/course/CourseService.java
+++ b/src/main/java/com/alimmit/golf/course/CourseService.java
@@ -44,4 +44,12 @@ public interface CourseService {
    * @param courseId Golf course identifier
    */
   void delete(UUID courseId);
+
+  /**
+   * Search golf courses by full-text query
+   *
+   * @param query Search query string
+   * @return list of matching CourseDto, ordered by relevance
+   */
+  List<CourseDto> search(String query);
 }

--- a/src/main/java/com/alimmit/golf/course/JpaCourseServiceImpl.java
+++ b/src/main/java/com/alimmit/golf/course/JpaCourseServiceImpl.java
@@ -1,9 +1,11 @@
 package com.alimmit.golf.course;
 
 import com.alimmit.golf.errors.NotFoundException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -63,5 +65,19 @@ class JpaCourseServiceImpl implements CourseService {
     courseRepository.findByIdForCurrentUser(courseId).orElseThrow(NotFoundException::new);
     teeRepository.deleteByCourse_Id(courseId);
     courseRepository.deleteById(courseId);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<CourseDto> search(String query) {
+    String sanitized = query.trim().replaceAll("[^\\w\\s]", "").trim();
+    if (sanitized.isBlank()) {
+      return List.of();
+    }
+    String tsQuery =
+        Arrays.stream(sanitized.split("\\s+"))
+            .map(word -> word + ":*")
+            .collect(Collectors.joining(" & "));
+    return courseRepository.search(tsQuery).stream().map(courseMapper::map).toList();
   }
 }

--- a/src/main/java/com/alimmit/golf/errors/GlobalControllerErrorHandler.java
+++ b/src/main/java/com/alimmit/golf/errors/GlobalControllerErrorHandler.java
@@ -1,5 +1,6 @@
 package com.alimmit.golf.errors;
 
+import jakarta.validation.ConstraintViolationException;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -52,6 +53,17 @@ public class GlobalControllerErrorHandler {
             .collect(Collectors.joining(","));
 
     return ResponseEntity.badRequest().body(joinedErrors);
+  }
+
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(ConstraintViolationException.class)
+  ResponseEntity<String> constraintViolationException(ConstraintViolationException exception) {
+    logger.debug("handle ConstraintViolationException | {}", exception.getMessage());
+    String message =
+        exception.getConstraintViolations().stream()
+            .map(v -> v.getPropertyPath() + ": " + v.getMessage())
+            .collect(Collectors.joining(", "));
+    return ResponseEntity.badRequest().body(message);
   }
 
   @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/resources/db/migration/V5__add_course_search_vector.sql
+++ b/src/main/resources/db/migration/V5__add_course_search_vector.sql
@@ -1,0 +1,12 @@
+ALTER TABLE course ADD COLUMN search_vector tsvector;
+
+CREATE INDEX idx_course_search_vector ON course USING GIN(search_vector);
+
+CREATE TRIGGER course_search_vector_update
+  BEFORE INSERT OR UPDATE ON course
+  FOR EACH ROW EXECUTE FUNCTION
+    tsvector_update_trigger(search_vector, 'pg_catalog.english', club, course, city, state);
+
+-- Populate existing rows
+UPDATE course SET search_vector = to_tsvector('pg_catalog.english',
+  coalesce(club,'') || ' ' || coalesce(course,'') || ' ' || coalesce(city,'') || ' ' || coalesce(state,''));

--- a/src/test/java/com/alimmit/golf/course/AbstractCourseControllerTest.java
+++ b/src/test/java/com/alimmit/golf/course/AbstractCourseControllerTest.java
@@ -57,4 +57,13 @@ class AbstractCourseControllerTest extends AbstractControllerMockMvc {
         delete(CourseConstants.COURSE_ENDPOINT + GlobalConstants.API_RECORD_SUFFIX, courseId),
         expect);
   }
+
+  ResultActions searchCourses(String query, JwtClaimApplier fn, ResultMatcher... expect)
+      throws Exception {
+    return performMockMvc(
+        fn,
+        get(CourseConstants.COURSE_ENDPOINT + CourseConstants.COURSE_SEARCH_SUFFIX)
+            .param("q", query),
+        expect);
+  }
 }

--- a/src/test/java/com/alimmit/golf/course/CourseControllerIT.java
+++ b/src/test/java/com/alimmit/golf/course/CourseControllerIT.java
@@ -97,6 +97,54 @@ class CourseControllerIT extends AbstractCourseControllerTest {
     deleteCourse(courseId, JwtPersona.forGaryGolfer(), status().isNotFound());
   }
 
+  @Test
+  void searchCourses_ExactWord() throws Exception {
+    createAndAssertCourse(JwtPersona.forGaryGolfer());
+
+    searchCourses("Test", JwtPersona.forGaryGolfer(), status().isOk())
+        .andExpect(jsonPath("$.length()").value(1))
+        .andExpect(jsonPath("$.[0].club").value("Test Club"));
+  }
+
+  @Test
+  void searchCourses_PartialWord() throws Exception {
+    createAndAssertCourse(JwtPersona.forGaryGolfer());
+
+    searchCourses("Tes", JwtPersona.forGaryGolfer(), status().isOk())
+        .andExpect(jsonPath("$.length()").value(1))
+        .andExpect(jsonPath("$.[0].club").value("Test Club"));
+  }
+
+  @Test
+  void searchCourses_MultiWord() throws Exception {
+    createAndAssertCourse(JwtPersona.forGaryGolfer());
+
+    searchCourses("Test Club", JwtPersona.forGaryGolfer(), status().isOk())
+        .andExpect(jsonPath("$.length()").value(1))
+        .andExpect(jsonPath("$.[0].club").value("Test Club"));
+  }
+
+  @Test
+  void searchCourses_SpecialCharsOnly_ReturnsEmpty() throws Exception {
+    createAndAssertCourse(JwtPersona.forGaryGolfer());
+
+    searchCourses("&|!", JwtPersona.forGaryGolfer(), status().isOk())
+        .andExpect(jsonPath("$.length()").value(0));
+  }
+
+  @Test
+  void searchCourses_MultiTenancy() throws Exception {
+    createAndAssertCourse(JwtPersona.forGaryGolfer());
+
+    // Gary finds his course
+    searchCourses("Test Club", JwtPersona.forGaryGolfer(), status().isOk())
+        .andExpect(jsonPath("$.length()").value(1));
+
+    // Pat finds nothing
+    searchCourses("Test Club", JwtPersona.forPatPutter(), status().isOk())
+        .andExpect(jsonPath("$.length()").value(0));
+  }
+
   private ResultActions createAndAssertCourse(JwtClaimApplier fn) throws Exception {
     return createCourse(REQUEST_BODY, fn, status().isCreated())
         .andExpectAll(

--- a/src/test/java/com/alimmit/golf/course/CourseControllerTest.java
+++ b/src/test/java/com/alimmit/golf/course/CourseControllerTest.java
@@ -261,4 +261,51 @@ class CourseControllerTest extends AbstractCourseControllerTest {
   void getCourseWithDisallowedScopes_ExpectForbidden(String scope) throws Exception {
     getCourse(UUID.randomUUID(), JwtPersona.forGaryGolfer(scope)).andExpect(status().isForbidden());
   }
+
+  @Test
+  void searchCourses_ExpectOk() throws Exception {
+    when(courseService.search("Acme"))
+        .thenReturn(
+            List.of(
+                new CourseDto(
+                    UUID.randomUUID(),
+                    Instant.now(),
+                    Instant.now(),
+                    "Acme Club",
+                    "Acme Course",
+                    "Anytown",
+                    USState.WISCONSIN)));
+
+    searchCourses("Acme", JwtPersona.forGaryGolfer())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(1))
+        .andExpectAll(
+            jsonPath("$.[0].club").value("Acme Club"),
+            jsonPath("$.[0].course").value("Acme Course"));
+  }
+
+  @Test
+  void searchCourses_BlankQuery_ExpectBadRequest() throws Exception {
+    searchCourses("", JwtPersona.forGaryGolfer()).andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void searchCourses_Unauthenticated_ExpectUnauthorized() throws Exception {
+    performWithoutAuth(
+            get(CourseConstants.COURSE_ENDPOINT + CourseConstants.COURSE_SEARCH_SUFFIX)
+                .param("q", "Acme"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        JwtPersona.SCOPE_READ_SCORECARD,
+        JwtPersona.SCOPE_WRITE_SCORECARD,
+        JwtPersona.SCOPE_READ_HANDICAP,
+        "",
+      })
+  void searchCourses_DisallowedScopes_ExpectForbidden(String scope) throws Exception {
+    searchCourses("Acme", JwtPersona.forGaryGolfer(scope)).andExpect(status().isForbidden());
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `GET /v1/course/search?q=` backed by PostgreSQL full-text search on `club`, `course`, `city`, and `state` fields
- Flyway migration (V5) adds a `tsvector` column maintained by a Postgres trigger with a GIN index for fast lookups
- Supports prefix matching (`"Iron"` finds `"Ironwood"`) and multi-word queries (`"Super Great"` finds `"Super Great Course"`) via per-word `:*` tsquery operators built in the service layer
- Input is sanitized in Java before reaching the database: special tsquery characters are stripped, and all-special-character inputs return an empty list without querying
- Results are user-scoped (multi-tenant) and ordered by `ts_rank` relevance
- Blank `q` parameter returns `400 Bad Request` via `@Validated` + `@NotBlank`; added `ConstraintViolationException` handler to `GlobalControllerErrorHandler`

## Test plan
- [ ] Unit tests: `./mvnw test -Dtest=CourseControllerTest` — covers 200 OK, blank query 400, unauthenticated 401, forbidden scopes 403
- [ ] Integration tests: `./mvnw test -Dtest=CourseControllerIT` — covers exact word, partial word, multi-word, all-special-chars, and multi-tenancy isolation
- [ ] Full suite: `./mvnw test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)