### PR TITLE
chore: add postman directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ build/
 
 ### Claude Code
 .claude/
+
+### Postman
+.postman/
+postman/


### PR DESCRIPTION
## Summary
- Adds `.postman/` and `postman/` to `.gitignore` to prevent local Postman collection files from being tracked

## Test plan
- [ ] No functional changes; verify `.gitignore` entries are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)