### PR TITLE
test: unit and integration tests for JpaHandicapServiceImpl

### DIFF
--- a/src/test/java/com/alimmit/golf/handicap/JpaHandicapServiceImplIT.java
+++ b/src/test/java/com/alimmit/golf/handicap/JpaHandicapServiceImplIT.java
@@ -1,0 +1,173 @@
+package com.alimmit.golf.handicap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.alimmit.golf.scorecard.ScorecardDto;
+import com.alimmit.golf.scorecard.ScorecardType;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.data.repository.query.SecurityEvaluationContextExtension;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({
+  JpaHandicapServiceImplIT.TestConfig.class,
+  JpaHandicapServiceImpl.class,
+  HandicapMapper.class,
+  HandicapCalculatorImpl.class
+})
+@TestPropertySource(locations = "classpath:application-test.properties")
+@Sql(scripts = "classpath:cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+class JpaHandicapServiceImplIT {
+
+  @TestConfiguration
+  @EnableJpaAuditing
+  static class TestConfig {
+
+    @Bean
+    AuditorAware<String> auditorAware() {
+      return () -> {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+          return Optional.empty();
+        }
+        return Optional.of(authentication.getName());
+      };
+    }
+
+    @Bean
+    SecurityEvaluationContextExtension securityEvaluationContextExtension() {
+      return new SecurityEvaluationContextExtension();
+    }
+  }
+
+  private final HandicapService handicapService;
+
+  @Autowired
+  JpaHandicapServiceImplIT(HandicapService handicapService) {
+    this.handicapService = handicapService;
+  }
+
+  @Test
+  void contextLoads() {
+    assertThat(handicapService).isNotNull();
+  }
+
+  @Test
+  @WithMockUser("123")
+  @Transactional(propagation = Propagation.NEVER)
+  void calculate_withInsufficientRounds_doesNotCreateHandicap() {
+    // Only 2 rounds of 18 holes = 36 holes total, below the 54-hole minimum
+    List<ScorecardDto> scorecards =
+        List.of(
+            createScorecard("123", ScorecardType.EIGHTEEN, 10.0),
+            createScorecard("123", ScorecardType.EIGHTEEN, 12.0));
+
+    handicapService.calculate(scorecards, "123");
+
+    Optional<HandicapDto> result = handicapService.getHandicap();
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @WithMockUser("123")
+  @Transactional(propagation = Propagation.NEVER)
+  void calculate_thenGetHandicap() {
+    handicapService.calculate(threeRoundScorecards("123"), "123");
+
+    Optional<HandicapDto> result = handicapService.getHandicap();
+
+    assertThat(result)
+        .isPresent()
+        .get()
+        .hasFieldOrProperty("handicapId")
+        .hasFieldOrProperty("createdAt")
+        .hasFieldOrProperty("lastModifiedAt")
+        .hasFieldOrPropertyWithValue("golferId", "123")
+        .hasFieldOrProperty("handicapIndex")
+        .hasFieldOrPropertyWithValue("totalRounds", 3);
+  }
+
+  @Test
+  @WithMockUser("123")
+  @Transactional(propagation = Propagation.NEVER)
+  void calculate_updatesExistingHandicap() {
+    handicapService.calculate(threeRoundScorecards("123"), "123");
+    HandicapDto initial = handicapService.getHandicap().orElseThrow();
+
+    handicapService.calculate(sixRoundScorecards("123"), "123");
+    HandicapDto updated = handicapService.getHandicap().orElseThrow();
+
+    assertThat(updated)
+        .hasFieldOrPropertyWithValue("handicapId", initial.handicapId())
+        .hasFieldOrPropertyWithValue("golferId", "123")
+        .hasFieldOrPropertyWithValue("totalRounds", 6);
+  }
+
+  @Test
+  @WithMockUser("123")
+  @Transactional(propagation = Propagation.NEVER)
+  void getHistory_returnsRevisionHistory() {
+    handicapService.calculate(threeRoundScorecards("123"), "123");
+    handicapService.calculate(sixRoundScorecards("123"), "123");
+
+    List<HandicapRevisionDto> history = handicapService.getHistory();
+
+    assertThat(history).hasSize(2);
+  }
+
+  private List<ScorecardDto> threeRoundScorecards(String golferId) {
+    return List.of(
+        createScorecard(golferId, ScorecardType.EIGHTEEN, 10.0),
+        createScorecard(golferId, ScorecardType.EIGHTEEN, 12.0),
+        createScorecard(golferId, ScorecardType.EIGHTEEN, 14.0));
+  }
+
+  private List<ScorecardDto> sixRoundScorecards(String golferId) {
+    return List.of(
+        createScorecard(golferId, ScorecardType.EIGHTEEN, 10.0),
+        createScorecard(golferId, ScorecardType.EIGHTEEN, 12.0),
+        createScorecard(golferId, ScorecardType.EIGHTEEN, 14.0),
+        createScorecard(golferId, ScorecardType.EIGHTEEN, 11.0),
+        createScorecard(golferId, ScorecardType.EIGHTEEN, 13.0),
+        createScorecard(golferId, ScorecardType.EIGHTEEN, 15.0));
+  }
+
+  private ScorecardDto createScorecard(String createdBy, ScorecardType type, Double differential) {
+    return new ScorecardDto(
+        UUID.randomUUID(),
+        Instant.now(),
+        createdBy,
+        LocalDate.now(),
+        "Test Club",
+        "Blue",
+        90,
+        72,
+        70.0,
+        113.0,
+        type,
+        differential,
+        false);
+  }
+}

--- a/src/test/java/com/alimmit/golf/handicap/JpaHandicapServiceImplTest.java
+++ b/src/test/java/com/alimmit/golf/handicap/JpaHandicapServiceImplTest.java
@@ -1,0 +1,162 @@
+package com.alimmit.golf.handicap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.alimmit.golf.errors.NotFoundException;
+import com.alimmit.golf.scorecard.ScorecardDto;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.history.Revision;
+import org.springframework.data.history.RevisionMetadata;
+import org.springframework.data.history.Revisions;
+
+@ExtendWith(MockitoExtension.class)
+class JpaHandicapServiceImplTest {
+
+  @Mock private HandicapCalculator handicapCalculator;
+  @Mock private HandicapMapper handicapMapper;
+  @Mock private HandicapRepository handicapRepository;
+
+  private JpaHandicapServiceImpl handicapService;
+
+  @BeforeEach
+  void setUp() {
+    handicapService =
+        new JpaHandicapServiceImpl(handicapCalculator, handicapMapper, handicapRepository);
+  }
+
+  @Test
+  void calculate_whenCalculatorReturnsEmpty_doesNotSave() {
+    List<ScorecardDto> scorecards = List.of();
+    when(handicapCalculator.calculate(scorecards)).thenReturn(Optional.empty());
+
+    handicapService.calculate(scorecards, "user-123");
+
+    verify(handicapRepository, never()).save(any());
+  }
+
+  @Test
+  void calculate_whenNoExistingHandicap_savesNewEntity() {
+    String golferId = "user-123";
+    List<ScorecardDto> scorecards = List.of();
+    HandicapCalculation calculation = createCalculation(12.3, 3, 3);
+    HandicapEntity newEntity = new HandicapEntity(golferId, 12.3, 3, 3);
+
+    when(handicapCalculator.calculate(scorecards)).thenReturn(Optional.of(calculation));
+    when(handicapRepository.findHandicapForUser(golferId)).thenReturn(Optional.empty());
+    when(handicapMapper.toEntity(calculation, golferId)).thenReturn(newEntity);
+
+    handicapService.calculate(scorecards, golferId);
+
+    verify(handicapRepository).save(newEntity);
+  }
+
+  @Test
+  void calculate_whenExistingHandicap_updatesAndSavesEntity() {
+    String golferId = "user-123";
+    List<ScorecardDto> scorecards = List.of();
+    HandicapCalculation calculation = createCalculation(11.1, 4, 5);
+    HandicapEntity existingEntity = new HandicapEntity(golferId, 12.3, 3, 3);
+    HandicapEntity updatedEntity = new HandicapEntity(golferId, 11.1, 4, 5);
+
+    when(handicapCalculator.calculate(scorecards)).thenReturn(Optional.of(calculation));
+    when(handicapRepository.findHandicapForUser(golferId)).thenReturn(Optional.of(existingEntity));
+    when(handicapMapper.updateEntity(existingEntity, calculation)).thenReturn(updatedEntity);
+
+    handicapService.calculate(scorecards, golferId);
+
+    verify(handicapRepository).save(updatedEntity);
+  }
+
+  @Test
+  void getHandicap() {
+    HandicapEntity entity = new HandicapEntity("user-123", 12.3, 3, 3);
+    HandicapDto dto = createDto(entity);
+    Optional<HandicapEntity> optionalEntity = Optional.of(entity);
+
+    when(handicapRepository.findHandicapForCurrentUser()).thenReturn(optionalEntity);
+    when(handicapMapper.toOptionalDto(optionalEntity)).thenReturn(Optional.of(dto));
+
+    Optional<HandicapDto> result = handicapService.getHandicap();
+
+    assertThat(result).isPresent().contains(dto);
+  }
+
+  @Test
+  void getHandicapNotFound() {
+    Optional<HandicapEntity> empty = Optional.empty();
+
+    when(handicapRepository.findHandicapForCurrentUser()).thenReturn(empty);
+    when(handicapMapper.toOptionalDto(empty)).thenReturn(Optional.empty());
+
+    Optional<HandicapDto> result = handicapService.getHandicap();
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void getHistory() {
+    HandicapEntity entity = new HandicapEntity("user-123", 12.3, 3, 3);
+    HandicapRevisionDto revisionDto = createRevisionDto();
+    Revision<Integer, HandicapEntity> revision = mock(Revision.class);
+    Revisions<Integer, HandicapEntity> revisions = Revisions.of(List.of(revision));
+
+    when(handicapRepository.findHandicapForCurrentUser()).thenReturn(Optional.of(entity));
+    when(handicapRepository.findRevisions(any())).thenReturn(revisions);
+    when(handicapMapper.toRevision(revision)).thenReturn(revisionDto);
+
+    List<HandicapRevisionDto> result = handicapService.getHistory();
+
+    assertThat(result).containsExactly(revisionDto);
+  }
+
+  @Test
+  void getHistoryNotFound() {
+    when(handicapRepository.findHandicapForCurrentUser()).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> handicapService.getHistory()).isInstanceOf(NotFoundException.class);
+  }
+
+  private HandicapCalculation createCalculation(Double index, int roundsUsed, int totalRounds) {
+    return new HandicapCalculation(index, roundsUsed, totalRounds, List.of(), Instant.now());
+  }
+
+  private HandicapDto createDto(HandicapEntity entity) {
+    return new HandicapDto(
+        entity.getId(),
+        entity.getGolferId(),
+        entity.getCreatedAt(),
+        entity.getLastModifiedAt(),
+        entity.getHandicapIndex(),
+        entity.getRoundsUsed(),
+        entity.getTotalRounds());
+  }
+
+  private HandicapRevisionDto createRevisionDto() {
+    return new HandicapRevisionDto(
+        UUID.randomUUID(),
+        "user-123",
+        Instant.now(),
+        Instant.now(),
+        12.3,
+        3,
+        3,
+        1,
+        RevisionMetadata.RevisionType.INSERT,
+        Instant.now());
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `JpaHandicapServiceImplTest` — 7 Mockito unit tests covering all three service methods (`calculate`, `getHandicap`, `getHistory`) including the create-vs-update branch in `calculate` and the `NotFoundException` paths
- Adds `JpaHandicapServiceImplIT` — 5 `@DataJpaTest` integration tests verifying end-to-end behavior: insufficient rounds produces no handicap, first calculation creates an entity, second calculation updates the same entity (same `handicapId`), and two calculations generate 2 Envers revision records

## Test plan
- [x] All new tests pass locally (`JpaHandicapServiceImplTest`, `JpaHandicapServiceImplIT`)
- [x] Full test suite passes (193 tests, 0 failures)
- [x] Spotless formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)