### PR TITLE
refactor: extract shared @TestConfiguration for JPA auditing (#53)

### DIFF
--- a/src/test/java/com/alimmit/golf/TestJpaAuditingConfig.java
+++ b/src/test/java/com/alimmit/golf/TestJpaAuditingConfig.java
@@ -1,0 +1,31 @@
+package com.alimmit.golf;
+
+import java.util.Optional;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.data.repository.query.SecurityEvaluationContextExtension;
+
+@TestConfiguration
+@EnableJpaAuditing
+public class TestJpaAuditingConfig {
+
+  @Bean
+  AuditorAware<String> auditorAware() {
+    return () -> {
+      Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+      if (authentication == null || !authentication.isAuthenticated()) {
+        return Optional.empty();
+      }
+      return Optional.of(authentication.getName());
+    };
+  }
+
+  @Bean
+  SecurityEvaluationContextExtension securityEvaluationContextExtension() {
+    return new SecurityEvaluationContextExtension();
+  }
+}

--- a/src/test/java/com/alimmit/golf/course/CourseRepositoryTest.java
+++ b/src/test/java/com/alimmit/golf/course/CourseRepositoryTest.java
@@ -2,20 +2,14 @@ package com.alimmit.golf.course;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.alimmit.golf.TestJpaAuditingConfig;
 import java.util.Optional;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.AuditorAware;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.data.repository.query.SecurityEvaluationContextExtension;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -26,32 +20,11 @@ import org.springframework.transaction.annotation.Transactional;
 @ActiveProfiles("test")
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import(CourseRepositoryTest.TestConfig.class)
+@Import(TestJpaAuditingConfig.class)
 @TestPropertySource(locations = "classpath:application-test.properties")
 @Sql(scripts = "classpath:cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 @Disabled
 class CourseRepositoryTest {
-
-  @TestConfiguration
-  @EnableJpaAuditing
-  static class TestConfig {
-
-    @Bean
-    AuditorAware<String> auditorAware() {
-      return () -> {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-          return Optional.empty();
-        }
-        return Optional.of(authentication.getName());
-      };
-    }
-
-    @Bean
-    SecurityEvaluationContextExtension securityEvaluationContextExtension() {
-      return new SecurityEvaluationContextExtension();
-    }
-  }
 
   private final CourseRepository courseRepository;
 

--- a/src/test/java/com/alimmit/golf/course/JpaCourseServiceImplIT.java
+++ b/src/test/java/com/alimmit/golf/course/JpaCourseServiceImplIT.java
@@ -2,19 +2,13 @@ package com.alimmit.golf.course;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.alimmit.golf.TestJpaAuditingConfig;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.AuditorAware;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.data.repository.query.SecurityEvaluationContextExtension;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -25,31 +19,10 @@ import org.springframework.transaction.annotation.Transactional;
 @ActiveProfiles("test")
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({JpaCourseServiceImplIT.TestConfig.class, JpaCourseServiceImpl.class, CourseMapper.class})
+@Import({TestJpaAuditingConfig.class, JpaCourseServiceImpl.class, CourseMapper.class})
 @TestPropertySource(locations = "classpath:application-test.properties")
 @Sql(scripts = "classpath:cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 class JpaCourseServiceImplIT {
-
-  @TestConfiguration
-  @EnableJpaAuditing
-  static class TestConfig {
-
-    @Bean
-    AuditorAware<String> auditorAware() {
-      return () -> {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-          return Optional.empty();
-        }
-        return Optional.of(authentication.getName());
-      };
-    }
-
-    @Bean
-    SecurityEvaluationContextExtension securityEvaluationContextExtension() {
-      return new SecurityEvaluationContextExtension();
-    }
-  }
 
   private final CourseService courseService;
 

--- a/src/test/java/com/alimmit/golf/course/JpaTeeServiceImplIT.java
+++ b/src/test/java/com/alimmit/golf/course/JpaTeeServiceImplIT.java
@@ -2,6 +2,7 @@ package com.alimmit.golf.course;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.alimmit.golf.TestJpaAuditingConfig;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
@@ -10,14 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.AuditorAware;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.data.repository.query.SecurityEvaluationContextExtension;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -29,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({
-  JpaTeeServiceImplIT.TestConfig.class,
+  TestJpaAuditingConfig.class,
   JpaTeeServiceImpl.class,
   TeeMapper.class,
   JpaCourseServiceImpl.class,
@@ -38,27 +32,6 @@ import org.springframework.transaction.annotation.Transactional;
 @TestPropertySource(locations = "classpath:application-test.properties")
 @Sql(scripts = "classpath:cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 class JpaTeeServiceImplIT {
-
-  @TestConfiguration
-  @EnableJpaAuditing
-  static class TestConfig {
-
-    @Bean
-    AuditorAware<String> auditorAware() {
-      return () -> {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-          return Optional.empty();
-        }
-        return Optional.of(authentication.getName());
-      };
-    }
-
-    @Bean
-    SecurityEvaluationContextExtension securityEvaluationContextExtension() {
-      return new SecurityEvaluationContextExtension();
-    }
-  }
 
   private final TeeService teeService;
   private final CourseService courseService;

--- a/src/test/java/com/alimmit/golf/course/TeeRepositoryTest.java
+++ b/src/test/java/com/alimmit/golf/course/TeeRepositoryTest.java
@@ -2,6 +2,7 @@ package com.alimmit.golf.course;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.alimmit.golf.TestJpaAuditingConfig;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
@@ -9,14 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.AuditorAware;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.data.repository.query.SecurityEvaluationContextExtension;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -27,31 +21,10 @@ import org.springframework.transaction.annotation.Transactional;
 @ActiveProfiles("test")
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import(TeeRepositoryTest.TestConfig.class)
+@Import(TestJpaAuditingConfig.class)
 @TestPropertySource(locations = "classpath:application-test.properties")
 @Sql(scripts = "classpath:cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 class TeeRepositoryTest {
-
-  @TestConfiguration
-  @EnableJpaAuditing
-  static class TestConfig {
-
-    @Bean
-    AuditorAware<String> auditorAware() {
-      return () -> {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-          return Optional.empty();
-        }
-        return Optional.of(authentication.getName());
-      };
-    }
-
-    @Bean
-    SecurityEvaluationContextExtension securityEvaluationContextExtension() {
-      return new SecurityEvaluationContextExtension();
-    }
-  }
 
   private final TeeRepository teeRepository;
   private final CourseRepository courseRepository;

--- a/src/test/java/com/alimmit/golf/handicap/HandicapRepositoryTest.java
+++ b/src/test/java/com/alimmit/golf/handicap/HandicapRepositoryTest.java
@@ -2,6 +2,7 @@ package com.alimmit.golf.handicap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.alimmit.golf.TestJpaAuditingConfig;
 import com.alimmit.golf.utils.JwtPersona;
 import java.util.List;
 import java.util.Optional;
@@ -10,17 +11,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.history.Revisions;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.data.repository.query.SecurityEvaluationContextExtension;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -31,31 +27,10 @@ import org.springframework.transaction.annotation.Transactional;
 @ActiveProfiles("test")
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({HandicapRepositoryTest.TestConfig.class})
+@Import(TestJpaAuditingConfig.class)
 @TestPropertySource(locations = "classpath:application-test.properties")
 @Sql(scripts = "classpath:cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 class HandicapRepositoryTest {
-
-  @TestConfiguration
-  @EnableJpaAuditing
-  static class TestConfig {
-
-    @Bean
-    AuditorAware<String> auditorAware() {
-      return () -> {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-          return Optional.empty();
-        }
-        return Optional.of(authentication.getName());
-      };
-    }
-
-    @Bean
-    SecurityEvaluationContextExtension securityEvaluationContextExtension() {
-      return new SecurityEvaluationContextExtension();
-    }
-  }
 
   private final HandicapRepository handicapRepository;
 

--- a/src/test/java/com/alimmit/golf/handicap/JpaHandicapServiceImplIT.java
+++ b/src/test/java/com/alimmit/golf/handicap/JpaHandicapServiceImplIT.java
@@ -2,6 +2,7 @@ package com.alimmit.golf.handicap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.alimmit.golf.TestJpaAuditingConfig;
 import com.alimmit.golf.scorecard.ScorecardDto;
 import com.alimmit.golf.scorecard.ScorecardType;
 import java.time.Instant;
@@ -13,14 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.AuditorAware;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.data.repository.query.SecurityEvaluationContextExtension;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -32,7 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({
-  JpaHandicapServiceImplIT.TestConfig.class,
+  TestJpaAuditingConfig.class,
   JpaHandicapServiceImpl.class,
   HandicapMapper.class,
   HandicapCalculatorImpl.class
@@ -40,27 +34,6 @@ import org.springframework.transaction.annotation.Transactional;
 @TestPropertySource(locations = "classpath:application-test.properties")
 @Sql(scripts = "classpath:cleanup.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 class JpaHandicapServiceImplIT {
-
-  @TestConfiguration
-  @EnableJpaAuditing
-  static class TestConfig {
-
-    @Bean
-    AuditorAware<String> auditorAware() {
-      return () -> {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-          return Optional.empty();
-        }
-        return Optional.of(authentication.getName());
-      };
-    }
-
-    @Bean
-    SecurityEvaluationContextExtension securityEvaluationContextExtension() {
-      return new SecurityEvaluationContextExtension();
-    }
-  }
 
   private final HandicapService handicapService;
 

--- a/src/test/java/com/alimmit/golf/scorecard/ScorecardRepositoryTest.java
+++ b/src/test/java/com/alimmit/golf/scorecard/ScorecardRepositoryTest.java
@@ -2,6 +2,7 @@ package com.alimmit.golf.scorecard;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.alimmit.golf.TestJpaAuditingConfig;
 import com.alimmit.golf.utils.JwtPersona;
 import java.time.LocalDate;
 import java.util.List;
@@ -11,16 +12,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.AuditorAware;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.data.repository.query.SecurityEvaluationContextExtension;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -30,31 +26,10 @@ import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
 @ActiveProfiles("test")
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import(ScorecardRepositoryTest.TestConfig.class)
+@Import(TestJpaAuditingConfig.class)
 @TestPropertySource(locations = "classpath:application-test.properties")
 @Sql(scripts = "classpath:cleanup.sql", executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
 class ScorecardRepositoryTest {
-
-  @TestConfiguration
-  @EnableJpaAuditing
-  static class TestConfig {
-
-    @Bean
-    AuditorAware<String> auditorAware() {
-      return () -> {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-          return Optional.empty();
-        }
-        return Optional.of(authentication.getName());
-      };
-    }
-
-    @Bean
-    SecurityEvaluationContextExtension securityEvaluationContextExtension() {
-      return new SecurityEvaluationContextExtension();
-    }
-  }
 
   private final ScorecardRepository scorecardRepository;
 


### PR DESCRIPTION
## Summary
- Extracts the duplicated `@TestConfiguration @EnableJpaAuditing static class TestConfig` present in 7 test classes into a single shared `TestJpaAuditingConfig` class in `com.alimmit.golf`
- Each affected test now uses `@Import(TestJpaAuditingConfig.class)` and has all TestConfig-related boilerplate removed

## Test plan
- [x] All 193 tests pass (`./mvnw test`)
- [x] `CourseRepositoryTest` remains `@Disabled` (unchanged behaviour)

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)