### PR TITLE
chore: gh-59 introduce dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/.local"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to enable automated dependency update PRs
- Configured for three ecosystems: **Maven** (`/`), **Docker** (`/.local`), **GitHub Actions** (`/`)
- Weekly update schedule for all ecosystems
- GitHub will automatically surface HIGH/CRITICAL security vulnerability PRs once this file is present

## Test plan
- [ ] Verify the PR checks pass
- [ ] Confirm Dependabot is active on the repo after merge (Settings → Code security → Dependabot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)