### PR TITLE
feat: optimize Dockerfile for security, size and build time (#58)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 .git
 .worktrees
-.mvn/wrapper/maven-wrapper.jar
 target/
 *.md
 documentation/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,26 +11,25 @@ RUN ./mvnw dependency:go-offline -q
 COPY src src
 RUN ./mvnw package -DskipTests -q
 
-# Extract layered jar for optimized runtime image
-RUN java -Djarmode=tools -jar target/golf-api-0.0.1-SNAPSHOT.jar extract --layers --launcher --destination target/extracted
+# Extract layered jar for optimized runtime image (Spring Boot 3.x compatible)
+RUN java -Djarmode=layertools -jar target/golf-api-0.0.1-SNAPSHOT.jar extract --destination target/extracted
 
 # Stage 2 — runtime
-FROM eclipse-temurin:21-jre-alpine AS runtime
+# Using Google's Distroless for a truly hardened, secure base image
+FROM gcr.io/distroless/java21-debian12:nonroot AS runtime
 
-RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 WORKDIR /app
 
-# Copy layers in order (least to most frequently changed)
-COPY --from=builder /build/target/extracted/dependencies ./
-COPY --from=builder /build/target/extracted/spring-boot-loader ./
-COPY --from=builder /build/target/extracted/snapshot-dependencies ./
-COPY --from=builder /build/target/extracted/application ./
+# The distroless nonroot user runs as uid/gid 65532
+# Copy layers in order with correct ownership
+COPY --chown=65532:65532 --from=builder /build/target/extracted/dependencies/ ./
+COPY --chown=65532:65532 --from=builder /build/target/extracted/spring-boot-loader/ ./
+COPY --chown=65532:65532 --from=builder /build/target/extracted/snapshot-dependencies/ ./
+COPY --chown=65532:65532 --from=builder /build/target/extracted/application/ ./
 
 EXPOSE 8080
 EXPOSE 9000
 
-STOPSIGNAL SIGTERM
-
-USER appuser
+# Distroless runs as nonroot user automatically
 
 ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-XX:MaxRAMPercentage=75.0", "org.springframework.boot.loader.launch.JarLauncher"]


### PR DESCRIPTION
Resolves #58

This PR finalizes the Dockerization of the application, strictly following the acceptance criteria requested in the issue.

Key Improvements & Fixes:

    Security (Hardened Base Image): Replaced the Alpine base image with Google's gcr.io/distroless/java21-debian12:nonroot for Stage 2. This drastically reduces the attack surface (no shell, no package managers) and runs the application entirely as a non-root user (uid 65532).

    Permissions Fix: Added --chown=65532:65532 to all COPY commands in the runtime stage to prevent permission denied errors within the container.

    Build Time & Layer Caching: Removed .mvn/wrapper/maven-wrapper.jar from .dockerignore to ensure ./mvnw dependency:go-offline works successfully without re-downloading the wrapper, utilizing Docker's layer cache properly.

    Optimized Image Size: Fixed the Spring Boot layertools extraction command for Spring Boot 3.5.x (-Djarmode=layertools) to correctly separate dependencies, spring-boot-loader, and application code into layers.

Testing:

    Successfully built the image locally.

    Verified that the Spring Boot application starts correctly, connects to a local PostgreSQL 18.1 container, and runs Flyway migrations successfully.

    Confirmed ports 8080 and 9000 are exposed and accessible.