### PR TITLE
feat: trunk-based release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Bump version and create tag
+        id: semver
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: patch
+          tag_prefix: v
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ steps.semver.outputs.new_version }}
+            ghcr.io/${{ github.repository }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        with:
+          tag_name: ${{ steps.semver.outputs.new_tag }}
+          name: ${{ steps.semver.outputs.new_tag }}
+          body: ${{ steps.semver.outputs.changelog }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY src src
 RUN ./mvnw package -DskipTests -q
 
 # Extract layered jar for optimized runtime image
-RUN java -Djarmode=tools -jar target/golf-api-0.0.1-SNAPSHOT.jar extract --layers --launcher --destination target/extracted
+RUN java -Djarmode=tools -jar target/golf-api-*.jar extract --layers --launcher --destination target/extracted
 
 # Stage 2 — runtime
 FROM eclipse-temurin:21-jre-alpine@sha256:6ad8ed080d9be96b61438ec3ce99388e294af216ed57356000c06070e85c5d5d AS runtime

--- a/documentation/plans/release-automation.md
+++ b/documentation/plans/release-automation.md
@@ -1,0 +1,70 @@
+# Release Automation Plan — Trunk-Based Development
+
+## Context
+Every push to `main` produces a versioned release: semver computed from conventional commits, a git tag on the real commit, a Docker image pushed to GHCR, and a GitHub Release with changelog. Tests are not re-run (already validated on PR via `test.yml`).
+
+---
+
+## Design decisions
+
+**Tag = version.** `pom.xml` is never updated by CI. The Docker image is tagged with the semver version by the workflow — the JAR name inside the container is irrelevant to deployment. This avoids bot commits, branch protection bypasses, and `[skip ci]` loop-prevention hacks.
+
+**Every push to main releases.** The tag action runs unconditionally on push to `main`. `chore:`, `refactor:`, etc. produce a patch bump via `default_bump: patch`.
+
+---
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `.github/workflows/release.yml` | Created |
+| `Dockerfile` | Fixed hardcoded JAR version on line 15 → glob |
+
+---
+
+## Workflow (6 steps)
+
+```
+push to main
+  → checkout (full history)
+  → mathieudutour/github-tag-action: compute semver + create tag on HEAD
+  → docker login to GHCR
+  → docker buildx setup
+  → build + push image (ghcr.io/<owner>/golf-api:<version> + :latest, GHA layer cache)
+  → softprops/action-gh-release: create release with changelog
+```
+
+## Semver bump rules
+
+| Commit prefix | Bump |
+|---------------|------|
+| `feat:` | minor |
+| `fix:` | patch |
+| everything else | patch (`default_bump: patch`) |
+| `BREAKING CHANGE` footer | major |
+
+---
+
+## GitHub repo settings prerequisite
+
+**Settings → Actions → General → Workflow permissions** → set to **"Read and write permissions"**
+
+This is the only prerequisite. No branch protection bypass needed.
+
+---
+
+## First release version
+
+No existing `v*` tags → base `0.0.0`. Most recent commit is `feat: spring boot 4 upgrade` → first release is **`v0.1.0`**. To start at `v1.0.0` instead: push tag `v0.9.9` manually before merging.
+
+---
+
+## TODO / Future improvements
+
+- **Maven CI-friendly versions** — update `pom.xml` to use `<version>${revision}</version>` with a default of `0.0.1-SNAPSHOT`, and pass `-Drevision=<version>` via a Docker build arg in the workflow. Produces a correctly versioned JAR inside the container without requiring bot commits to main. See: https://maven.apache.org/maven-ci-friendly.html
+
+---
+
+## Docker image location
+
+`ghcr.io/<owner>/golf-api` — visible under the repository's Packages sidebar. Visibility inherits from the repo (private repo → private image). Pull requires a PAT or deploy key with `read:packages` scope.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml`: on every push to `main`, computes the next semver from conventional commits, creates a git tag on `HEAD`, builds and pushes a Docker image to GHCR, and publishes a GitHub Release with an auto-generated changelog
- Fixes `Dockerfile` line 15: replaces hardcoded `golf-api-0.0.1-SNAPSHOT.jar` with a glob (`golf-api-*.jar`) so the layered JAR extraction works regardless of version
- Tests are **not** re-run on release — already validated on PR via `test.yml`
- `pom.xml` is never updated by CI — the git tag is the authoritative version

## Semver bump rules
| Commit prefix | Bump |
|---|---|
| `feat:` | minor |
| `fix:` | patch |
| everything else | patch |
| `BREAKING CHANGE` footer | major |

## Before merging — one GitHub setting required
**Settings → Actions → General → Workflow permissions** → set to **"Read and write permissions"**

## Test plan
- [ ] Confirm Actions workflow permissions are set to read/write
- [ ] Merge PR and verify the Release job completes in the Actions tab
- [ ] Confirm `v0.1.0` tag is created on the merge commit
- [ ] Confirm GitHub Release `v0.1.0` exists with changelog
- [ ] Confirm `ghcr.io/tim-mila/golf-api:0.1.0` and `:latest` are visible under Packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)