### PR TITLE
chore: restrict test workflow GITHUB_TOKEN to contents read

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ name: Test
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: read` to `test.yml`
- Resolves code scanning alert #1 (`actions/missing-workflow-permissions`)
- The test workflow only checks out code and runs Maven tests — no write permissions required

## Test plan
- [ ] Verify code scanning alert #1 is resolved after merge
- [ ] Confirm test workflow still passes on PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)