### PR TITLE
chore: add CodeQL scanning and npm Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,11 @@ updates:
     schedule:
       interval: "weekly"
 
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,32 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '0 8 * * 1'   # weekly, Monday 8am UTC
+
+permissions: {}
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [java-kotlin, javascript-typescript, actions]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - uses: github/codeql-action/autobuild@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+
+      - uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,6 +27,14 @@ jobs:
         with:
           languages: ${{ matrix.language }}
 
+      - name: Set up JDK 25
+        if: matrix.language == 'java-kotlin'
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: 'maven'
+
       - uses: github/codeql-action/autobuild@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
 
       - uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3


### PR DESCRIPTION
## Summary
- Adds `codeql.yml` scanning three languages in a matrix:
  - `java-kotlin` — Spring Boot API
  - `javascript-typescript` — Next.js frontend
  - `actions` — GitHub Actions workflows (already covered by default setup; now code-as-config)
- Runs on push to `main`, all PRs, and weekly on Monday 8am UTC
- All actions SHA-pinned, consistent with existing workflows
- Adds `npm` ecosystem to `dependabot.yml` for `web/` dependency updates

## Test plan
- [ ] CodeQL workflow appears in Actions tab and all three matrix jobs run
- [ ] Dependabot begins opening npm PRs for `web/` on next weekly schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)