### PR TITLE
feat(web): add Dockerfile and enable standalone output

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,31 @@
+# Stage 1: Install dependencies
+FROM node:24-alpine AS deps
+WORKDIR /app
+COPY web/package.json web/package-lock.json ./
+RUN npm ci
+
+# Stage 2: Build
+FROM node:24-alpine AS build
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY web/ .
+
+RUN npm run build
+
+# Stage 3: Runtime
+FROM node:24-alpine AS runtime
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+RUN addgroup -S nodejs && adduser -S nextjs -G nodejs
+USER nextjs
+
+COPY --from=build /app/public ./public
+COPY --from=build --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=build --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+EXPOSE 3000
+ENV PORT=3000
+CMD ["node", "server.js"]

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Adds `web/Dockerfile` — three-stage build (deps → build → runtime) using `node:24-alpine`
- Enables `output: "standalone"` in `next.config.ts` for a minimal runtime image
- Build context is the repo root: `docker build -f web/Dockerfile -t golf-web .`
- Image size: ~300MB

Also updated `.local/docker-compose.yaml` (gitignored) to add the `golf-web` service under the `app` profile, with healthchecks on postgres and golf-api.

## Test plan
- [ ] `web-test.yml` CI passes (`tsc --noEmit`)
- [ ] `docker build -f web/Dockerfile -t golf-web .` succeeds from repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)