### PR TITLE
chore(web): harden npm install with audit and --ignore-scripts

### DIFF
--- a/.github/workflows/web-release.yml
+++ b/.github/workflows/web-release.yml
@@ -23,6 +23,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Audit dependencies
+        run: cd web && npm audit --audit-level=high
+
       - name: Bump version and create tag
         id: semver
         uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2

--- a/.github/workflows/web-test.yml
+++ b/.github/workflows/web-test.yml
@@ -35,9 +35,13 @@ jobs:
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
+      - name: Audit dependencies
+        if: steps.web-check.outputs.exists == 'true'
+        run: cd web && npm audit --audit-level=high
+
       - name: Install dependencies
         if: steps.web-check.outputs.exists == 'true'
-        run: cd web && npm ci
+        run: cd web && npm ci --ignore-scripts
 
       - name: Generate API client
         if: steps.web-check.outputs.exists == 'true'

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:24-alpine AS deps
 WORKDIR /app
 COPY web/package.json web/package-lock.json ./
-RUN npm ci
+RUN npm audit --audit-level=high && npm ci --ignore-scripts
 
 # Stage 2: Build
 FROM node:24-alpine AS build

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "prebuild": "npm run generate-api",
     "start": "next start",
     "local-setup": "op inject -i ../.local/.env.web.example -o .env.local -f",
+    "install:local": "npm audit --audit-level=high && npm ci --ignore-scripts",
     "test": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Adds `npm audit --audit-level=high` before every `npm ci` — blocks on high/critical vulnerabilities, passes on low/moderate
- Adds `--ignore-scripts` to every `npm ci` — prevents postinstall scripts from executing during dependency installation (primary npm supply chain attack vector)
- Applied consistently across: `web/Dockerfile` (deps stage), `web-test.yml` (CI), `web-release.yml` (CI, runs before version bump so a failing audit doesn't create a spurious tag)

## Notes
- `--audit-level=high` can be tightened to `--audit-level=moderate` when the project is more stable
- `npm audit` reads `package-lock.json` against the npm advisory database — no `node_modules` required
- The Dockerfile change also covers the release workflow's Docker build path

## Test plan
- [ ] CI passes on this PR
- [ ] Verify `npm audit` step appears as a named step in the Actions run log

🤖 Generated with [Claude Code](https://claude.com/claude-code)