### PR TITLE
feat(web): add server-side API client and BFF proxy route handlers

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,7 +12,8 @@
         "@hey-api/client-next": "^0.5.1",
         "next": "16.2.6",
         "react": "19.2.6",
-        "react-dom": "19.2.6"
+        "react-dom": "19.2.6",
+        "server-only": "^0.0.1"
       },
       "devDependencies": {
         "@hey-api/openapi-ts": "^0.97.1",
@@ -2209,6 +2210,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.34.5",

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,8 @@
     "@hey-api/client-next": "^0.5.1",
     "next": "16.2.6",
     "react": "19.2.6",
-    "react-dom": "19.2.6"
+    "react-dom": "19.2.6",
+    "server-only": "^0.0.1"
   },
   "devDependencies": {
     "@hey-api/openapi-ts": "^0.97.1",

--- a/web/src/app/api/proxy/course/[id]/route.ts
+++ b/web/src/app/api/proxy/course/[id]/route.ts
@@ -1,0 +1,33 @@
+import { type NextRequest } from 'next/server';
+import { getApiClient } from '@/lib/api/server';
+import { courseDelete, coursePatch } from '@/lib/api/generated/sdk.gen';
+import type { PatchCourseRequest } from '@/lib/api/generated/types.gen';
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  let apiClient;
+  try {
+    apiClient = await getApiClient();
+  } catch {
+    return new Response(null, { status: 401 });
+  }
+
+  const { id } = await params;
+  const body: PatchCourseRequest = await req.json();
+  const { data, error, response } = await coursePatch({ client: apiClient, path: { id }, body });
+  if (!response) return new Response(null, { status: 502 });
+  return Response.json(data ?? error, { status: response.status });
+}
+
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  let apiClient;
+  try {
+    apiClient = await getApiClient();
+  } catch {
+    return new Response(null, { status: 401 });
+  }
+
+  const { id } = await params;
+  const { response } = await courseDelete({ client: apiClient, path: { id } });
+  if (!response) return new Response(null, { status: 502 });
+  return new Response(null, { status: response.status });
+}

--- a/web/src/app/api/proxy/course/[id]/route.ts
+++ b/web/src/app/api/proxy/course/[id]/route.ts
@@ -4,30 +4,26 @@ import { courseDelete, coursePatch } from '@/lib/api/generated/sdk.gen';
 import type { PatchCourseRequest } from '@/lib/api/generated/types.gen';
 
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  let apiClient;
-  try {
-    apiClient = await getApiClient();
-  } catch {
+  const client = await getApiClient().catch(() => null);
+  if (!client) {
     return new Response(null, { status: 401 });
   }
 
   const { id } = await params;
   const body: PatchCourseRequest = await req.json();
-  const { data, error, response } = await coursePatch({ client: apiClient, path: { id }, body });
-  if (!response) return new Response(null, { status: 502 });
+  const { data, error, response } = await coursePatch({ client, path: { id }, body });
+  if (!response) {return new Response(null, { status: 502 });}
   return Response.json(data ?? error, { status: response.status });
 }
 
 export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
-  let apiClient;
-  try {
-    apiClient = await getApiClient();
-  } catch {
+  const client = await getApiClient().catch(() => null);
+  if (!client) {
     return new Response(null, { status: 401 });
   }
 
   const { id } = await params;
-  const { response } = await courseDelete({ client: apiClient, path: { id } });
-  if (!response) return new Response(null, { status: 502 });
+  const { response } = await courseDelete({ client, path: { id } });
+  if (!response) {return new Response(null, { status: 502 });}
   return new Response(null, { status: response.status });
 }

--- a/web/src/app/api/proxy/course/route.ts
+++ b/web/src/app/api/proxy/course/route.ts
@@ -1,0 +1,18 @@
+import { type NextRequest } from 'next/server';
+import { getApiClient } from '@/lib/api/server';
+import { courseCreate } from '@/lib/api/generated/sdk.gen';
+import type { CreateCourseRequest } from '@/lib/api/generated/types.gen';
+
+export async function POST(req: NextRequest) {
+  let apiClient;
+  try {
+    apiClient = await getApiClient();
+  } catch {
+    return new Response(null, { status: 401 });
+  }
+
+  const body: CreateCourseRequest = await req.json();
+  const { data, error, response } = await courseCreate({ client: apiClient, body });
+  if (!response) return new Response(null, { status: 502 });
+  return Response.json(data ?? error, { status: response.status });
+}

--- a/web/src/app/api/proxy/course/route.ts
+++ b/web/src/app/api/proxy/course/route.ts
@@ -4,15 +4,13 @@ import { courseCreate } from '@/lib/api/generated/sdk.gen';
 import type { CreateCourseRequest } from '@/lib/api/generated/types.gen';
 
 export async function POST(req: NextRequest) {
-  let apiClient;
-  try {
-    apiClient = await getApiClient();
-  } catch {
+  const client = await getApiClient().catch(() => null);
+  if (!client) {
     return new Response(null, { status: 401 });
   }
 
   const body: CreateCourseRequest = await req.json();
-  const { data, error, response } = await courseCreate({ client: apiClient, body });
-  if (!response) return new Response(null, { status: 502 });
+  const { data, error, response } = await courseCreate({ client, body });
+  if (!response) {return new Response(null, { status: 502 });}
   return Response.json(data ?? error, { status: response.status });
 }

--- a/web/src/app/api/proxy/scorecard/[id]/route.ts
+++ b/web/src/app/api/proxy/scorecard/[id]/route.ts
@@ -2,15 +2,13 @@ import { getApiClient } from '@/lib/api/server';
 import { scorecardDelete } from '@/lib/api/generated/sdk.gen';
 
 export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
-  let apiClient;
-  try {
-    apiClient = await getApiClient();
-  } catch {
+  const client = await getApiClient().catch(() => null);
+  if (!client) {
     return new Response(null, { status: 401 });
   }
 
   const { id } = await params;
-  const { response } = await scorecardDelete({ client: apiClient, path: { id } });
-  if (!response) return new Response(null, { status: 502 });
+  const { response } = await scorecardDelete({ client, path: { id } });
+  if (!response) {return new Response(null, { status: 502 });}
   return new Response(null, { status: response.status });
 }

--- a/web/src/app/api/proxy/scorecard/[id]/route.ts
+++ b/web/src/app/api/proxy/scorecard/[id]/route.ts
@@ -1,0 +1,16 @@
+import { getApiClient } from '@/lib/api/server';
+import { scorecardDelete } from '@/lib/api/generated/sdk.gen';
+
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  let apiClient;
+  try {
+    apiClient = await getApiClient();
+  } catch {
+    return new Response(null, { status: 401 });
+  }
+
+  const { id } = await params;
+  const { response } = await scorecardDelete({ client: apiClient, path: { id } });
+  if (!response) return new Response(null, { status: 502 });
+  return new Response(null, { status: response.status });
+}

--- a/web/src/app/api/proxy/scorecard/route.ts
+++ b/web/src/app/api/proxy/scorecard/route.ts
@@ -1,0 +1,18 @@
+import { type NextRequest } from 'next/server';
+import { getApiClient } from '@/lib/api/server';
+import { scorecardCreate } from '@/lib/api/generated/sdk.gen';
+import type { ScorecardRequestDto } from '@/lib/api/generated/types.gen';
+
+export async function POST(req: NextRequest) {
+  let apiClient;
+  try {
+    apiClient = await getApiClient();
+  } catch {
+    return new Response(null, { status: 401 });
+  }
+
+  const body: ScorecardRequestDto = await req.json();
+  const { data, error, response } = await scorecardCreate({ client: apiClient, body });
+  if (!response) return new Response(null, { status: 502 });
+  return Response.json(data ?? error, { status: response.status });
+}

--- a/web/src/app/api/proxy/scorecard/route.ts
+++ b/web/src/app/api/proxy/scorecard/route.ts
@@ -4,15 +4,13 @@ import { scorecardCreate } from '@/lib/api/generated/sdk.gen';
 import type { ScorecardRequestDto } from '@/lib/api/generated/types.gen';
 
 export async function POST(req: NextRequest) {
-  let apiClient;
-  try {
-    apiClient = await getApiClient();
-  } catch {
+  const client = await getApiClient().catch(() => null);
+  if (!client) {
     return new Response(null, { status: 401 });
   }
 
   const body: ScorecardRequestDto = await req.json();
-  const { data, error, response } = await scorecardCreate({ client: apiClient, body });
-  if (!response) return new Response(null, { status: 502 });
+  const { data, error, response } = await scorecardCreate({ client, body });
+  if (!response) {return new Response(null, { status: 502 });}
   return Response.json(data ?? error, { status: response.status });
 }

--- a/web/src/app/api/proxy/tee/[id]/route.ts
+++ b/web/src/app/api/proxy/tee/[id]/route.ts
@@ -1,0 +1,33 @@
+import { type NextRequest } from 'next/server';
+import { getApiClient } from '@/lib/api/server';
+import { teeDelete, teePatch } from '@/lib/api/generated/sdk.gen';
+import type { PatchTeeRequest } from '@/lib/api/generated/types.gen';
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  let apiClient;
+  try {
+    apiClient = await getApiClient();
+  } catch {
+    return new Response(null, { status: 401 });
+  }
+
+  const { id } = await params;
+  const body: PatchTeeRequest = await req.json();
+  const { data, error, response } = await teePatch({ client: apiClient, path: { id }, body });
+  if (!response) return new Response(null, { status: 502 });
+  return Response.json(data ?? error, { status: response.status });
+}
+
+export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
+  let apiClient;
+  try {
+    apiClient = await getApiClient();
+  } catch {
+    return new Response(null, { status: 401 });
+  }
+
+  const { id } = await params;
+  const { response } = await teeDelete({ client: apiClient, path: { id } });
+  if (!response) return new Response(null, { status: 502 });
+  return new Response(null, { status: response.status });
+}

--- a/web/src/app/api/proxy/tee/[id]/route.ts
+++ b/web/src/app/api/proxy/tee/[id]/route.ts
@@ -4,30 +4,26 @@ import { teeDelete, teePatch } from '@/lib/api/generated/sdk.gen';
 import type { PatchTeeRequest } from '@/lib/api/generated/types.gen';
 
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  let apiClient;
-  try {
-    apiClient = await getApiClient();
-  } catch {
+  const client = await getApiClient().catch(() => null);
+  if (!client) {
     return new Response(null, { status: 401 });
   }
 
   const { id } = await params;
   const body: PatchTeeRequest = await req.json();
-  const { data, error, response } = await teePatch({ client: apiClient, path: { id }, body });
-  if (!response) return new Response(null, { status: 502 });
+  const { data, error, response } = await teePatch({ client, path: { id }, body });
+  if (!response) {return new Response(null, { status: 502 });}
   return Response.json(data ?? error, { status: response.status });
 }
 
 export async function DELETE(_req: Request, { params }: { params: Promise<{ id: string }> }) {
-  let apiClient;
-  try {
-    apiClient = await getApiClient();
-  } catch {
+  const client = await getApiClient().catch(() => null);
+  if (!client) {
     return new Response(null, { status: 401 });
   }
 
   const { id } = await params;
-  const { response } = await teeDelete({ client: apiClient, path: { id } });
-  if (!response) return new Response(null, { status: 502 });
+  const { response } = await teeDelete({ client, path: { id } });
+  if (!response) {return new Response(null, { status: 502 });}
   return new Response(null, { status: response.status });
 }

--- a/web/src/app/api/proxy/tee/route.ts
+++ b/web/src/app/api/proxy/tee/route.ts
@@ -4,15 +4,13 @@ import { teeCreate } from '@/lib/api/generated/sdk.gen';
 import type { CreateTeeRequest } from '@/lib/api/generated/types.gen';
 
 export async function POST(req: NextRequest) {
-  let apiClient;
-  try {
-    apiClient = await getApiClient();
-  } catch {
+  const client = await getApiClient().catch(() => null);
+  if (!client) {
     return new Response(null, { status: 401 });
   }
 
   const body: CreateTeeRequest = await req.json();
-  const { data, error, response } = await teeCreate({ client: apiClient, body });
-  if (!response) return new Response(null, { status: 502 });
+  const { data, error, response } = await teeCreate({ client, body });
+  if (!response) {return new Response(null, { status: 502 });}
   return Response.json(data ?? error, { status: response.status });
 }

--- a/web/src/app/api/proxy/tee/route.ts
+++ b/web/src/app/api/proxy/tee/route.ts
@@ -1,0 +1,18 @@
+import { type NextRequest } from 'next/server';
+import { getApiClient } from '@/lib/api/server';
+import { teeCreate } from '@/lib/api/generated/sdk.gen';
+import type { CreateTeeRequest } from '@/lib/api/generated/types.gen';
+
+export async function POST(req: NextRequest) {
+  let apiClient;
+  try {
+    apiClient = await getApiClient();
+  } catch {
+    return new Response(null, { status: 401 });
+  }
+
+  const body: CreateTeeRequest = await req.json();
+  const { data, error, response } = await teeCreate({ client: apiClient, body });
+  if (!response) return new Response(null, { status: 502 });
+  return Response.json(data ?? error, { status: response.status });
+}

--- a/web/src/lib/api/server.ts
+++ b/web/src/lib/api/server.ts
@@ -1,0 +1,11 @@
+import 'server-only';
+import { createClient, createConfig } from '@/lib/api/generated/client';
+import { auth0 } from '@/lib/auth0';
+
+export async function getApiClient() {
+  const { token } = await auth0.getAccessToken();
+  return createClient(createConfig({
+    baseUrl: process.env.API_BASE_URL!,
+    auth: token,
+  }));
+}


### PR DESCRIPTION
## Summary
- Adds `web/src/lib/api/server.ts` — `getApiClient()` factory; imports `server-only` to prevent accidental browser bundling; calls `auth0.getAccessToken()` (auto-refreshes expired tokens) and returns a hey-api client configured with `API_BASE_URL` and the Bearer token
- Adds Route Handlers under `web/src/app/api/proxy/` for all mutation operations — scorecard (POST, DELETE), course (POST, PATCH, DELETE), tee (POST, PATCH, DELETE)
- All Route Handlers: 401 on missing session, 502 on unreachable upstream, otherwise forward Spring Boot's status and body verbatim
- Adds `server-only` dependency

## Architecture
- **Server Components** → `getApiClient()` → Spring Boot directly (server-to-server, token in memory)
- **Client Components** → `/api/proxy/*` Route Handlers → `getApiClient()` → Spring Boot (token never reaches browser)
- Read operations (GET) happen in Server Components only — no proxy routes needed for reads

## Test plan
- [ ] `tsc --noEmit` passes (CI)
- [ ] Sign in, call a proxy route with a valid session → 201/204 from Spring Boot forwarded correctly
- [ ] Call a proxy route without a session → 401
- [ ] Call a proxy route with Spring Boot down → 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)